### PR TITLE
Fixing repo links to tags/contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Please read [CONTRIBUTING.md](https://gist.github.com/PurpleBooth/b24679402957c6
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/your/project/tags). 
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/Deverick-Simpson/Deverick.io/tags). 
 
 ## Authors
 
 * **Deverick Simpson** - *Initial work* - [Deverick](https://github.com/Deverick-Simpson)
 
-See also the list of [contributors](https://github.com/Deverick-Simpson/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/Deverick-Simpson/Deverick.io/contributors) who participated in this project.
 
 ## License
 


### PR DESCRIPTION
I'll let you add the license file yourself.
